### PR TITLE
Fix dependency error when requiring a proxy

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -164,9 +164,9 @@ class yum (
     contain yum::package
     contain yum::config
     contain yum::service
-
-    Class['yum::package'] ->
+    
     Class['yum::config'] ->
+    Class['yum::package'] ->
     Class['yum::service']
   }
 }


### PR DESCRIPTION
When you need a proxy to install any package it must be set before attempting to install yum...